### PR TITLE
initial commit of Jax integration [WIP]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ scikit-learn
 numba
 setuptools_scm
 pillow
+jax


### PR DESCRIPTION
Jax seems to offer quite substantial speed improvements on things like svd compared to numpy and scipy, even in the absence of GPU or TPU.

Let's see if this is the case. we will add jax to fracridge, and then test it with glm_denoisesingletrial

- [ ] add jax to requirements.
- [ ] try and catch jax, else use scipy